### PR TITLE
Untitled

### DIFF
--- a/tosa-test/test-src/tosa/loader/parser/mysql/MySQL51SQLParserTest.java
+++ b/tosa-test/test-src/tosa/loader/parser/mysql/MySQL51SQLParserTest.java
@@ -32,6 +32,39 @@ public class MySQL51SQLParserTest {
   }
 
   @Test
+  public void createUserIgnored() {
+    List<TableData> tableData = parse("CREATE USER IF NOT EXISTS SA SALT '12bd38540d6d1b6d' HASH 'badd644249ad1cdbb9efd2717b285af20c7040ea835090cae2c65b1e11785ded' ADMIN;\n" +
+        "CREATE TABLE \"Bar\"(\n" +
+        "    \"id\" INT PRIMARY KEY AUTO_INCREMENT,\n" +
+        "    \"Date\" DATE,\n" +
+        "    \"Misc\" VARCHAR(50)\n" +
+        ");");
+
+    assertSingleTable(table("Bar",
+            column("id", DBColumnTypeImpl.INTEGER_ITYPE, Types.INTEGER),
+            column("Date", DBColumnTypeImpl.DATE_ITYPE, Types.DATE),
+            column("Misc", DBColumnTypeImpl.STRING_ITYPE, Types.VARCHAR)),
+        tableData);
+  }
+
+  @Test
+  public void insertIgnored() {
+    List<TableData> tableData = parse("INSERT INTO \"User\"(\"id\", \"Name\", \"Hash\", \"Salt\") VALUES\n" +
+        "(1, 'admin', 'ilPQ0UXsOZMvdpyKmsqlyGdYc9uXzCREqOb7AL1dv2A=', 'ObnNMzW+Ll0LnQP/Hnjb8MsXB8PTaeKKdDPqJvwmtzCQ4EW0FFLsoCqGkInD+rGCKQ42NXFEBSs6TlDQfHuu5xpAT2mX11YhYJv3W8CK5UtMLvYyOg1OzyuSNLsz479wlwmOaZjiketXbPTyQgRMNJIBKk8qHgqLcC08dBVEtT8=');\n" +
+        "CREATE TABLE \"Bar\"(\n" +
+        "    \"id\" INT PRIMARY KEY AUTO_INCREMENT,\n" +
+        "    \"Date\" DATE,\n" +
+        "    \"Misc\" VARCHAR(50)\n" +
+        ");");
+
+    assertSingleTable(table("Bar",
+            column("id", DBColumnTypeImpl.INTEGER_ITYPE, Types.INTEGER),
+            column("Date", DBColumnTypeImpl.DATE_ITYPE, Types.DATE),
+            column("Misc", DBColumnTypeImpl.STRING_ITYPE, Types.VARCHAR)),
+        tableData);
+  }
+
+  @Test
   public void bitDataType() {
     assertColumnDataType("BIT", column("test", DBColumnTypeImpl.BOOLEAN_ITYPE, Types.BIT));
     assertColumnDataType("bIt", column("test", DBColumnTypeImpl.BOOLEAN_ITYPE, Types.BIT));

--- a/tosa/src/tosa/loader/parser/DDLDBDataSource.java
+++ b/tosa/src/tosa/loader/parser/DDLDBDataSource.java
@@ -29,7 +29,7 @@ public class DDLDBDataSource implements IDBDataSource {
       String path = module.getResourceAccess().pathRelativeToRoot(ddlFile.getSecond());
       IFile connectionFile = module.getResourceAccess().findFirstFile(path.substring(0, path.length() - ".ddl".length()) + ".dbc");
       String connectionString = null;
-      if (connectionFile.exists()) {
+      if (connectionFile != null && connectionFile.exists()) {
         connectionString = readFile(connectionFile);
       }
       List<TableData> tables = new MySQL51SQLParser().parseDDLFile(readFile(ddlFile.getSecond()));

--- a/tosa/src/tosa/loader/parser/SQLTokenizer.java
+++ b/tosa/src/tosa/loader/parser/SQLTokenizer.java
@@ -89,4 +89,8 @@ public class SQLTokenizer {
       _currentToken++;
     }
   }
+
+  public boolean eof() {
+    return _currentToken == _tokens.size();
+  }
 }

--- a/tosa/src/tosa/loader/parser/mysql/MySQL51SQLParser.java
+++ b/tosa/src/tosa/loader/parser/mysql/MySQL51SQLParser.java
@@ -65,8 +65,11 @@ public class MySQL51SQLParser implements SQLParserConstants, ISQLParser {
     _tokenizer = new SQLTokenizer(fileContents);
     List<TableData> tables = new ArrayList<TableData>();
     // TODO - AHK - Other Create calls?  Other stuff?  Closing semi-colon?
-    for (TableData table = parseCreate(); table != null; table = parseCreate()) {
-      tables.add(table);
+    while (!eof()) {
+      TableData table = parseCreate();
+      if (table != null) {
+        tables.add(table);
+      }
     }
     return tables;
   }
@@ -85,6 +88,10 @@ public class MySQL51SQLParser implements SQLParserConstants, ISQLParser {
 
   private void expect(String expected) {
     _tokenizer.expectIgnoreCase(expected);
+  }
+
+  private boolean eof() {
+    return _tokenizer.eof();
   }
 
   private String stripQuotes(String str) {
@@ -119,35 +126,46 @@ CREATE [TEMPORARY] TABLE [IF NOT EXISTS] tbl_name
   private TableData parseCreate() {
     if (accept(CREATE)) {
       accept(TEMPORARY); // Discard; we don't care
-      expect(TABLE);
-      accept(IF, NOT, EXISTS);
-      String tableName = stripQuotes(consumeToken());
-      List<ColumnData> columns = null;
-      if (accept(LIKE)) {
-        String likeTableName = consumeToken();
-        // TODO - AHK - And what do we do with it, exactly?
-      } else if (accept(OPEN_PAREN, LIKE)) {
-        String likeTableName = consumeToken();
-        expect(CLOSE_PAREN);
-        // TODO - AHK - And what do we do with it, exactly?
-      } else if (accept(OPEN_PAREN)) {
-        columns = parseCreateDefinitions();
-        expect(CLOSE_PAREN);
-        parseTableOptions();
-        parsePartitionOptions();
-        parseSelectStatement();
+      if(accept(TABLE)) {
+        accept(IF, NOT, EXISTS);
+        String tableName = stripQuotes(consumeToken());
+        List<ColumnData> columns = null;
+        if (accept(LIKE)) {
+          String likeTableName = consumeToken();
+          // TODO - AHK - And what do we do with it, exactly?
+        } else if (accept(OPEN_PAREN, LIKE)) {
+          String likeTableName = consumeToken();
+          expect(CLOSE_PAREN);
+          // TODO - AHK - And what do we do with it, exactly?
+        } else if (accept(OPEN_PAREN)) {
+          columns = parseCreateDefinitions();
+          expect(CLOSE_PAREN);
+          parseTableOptions();
+          parsePartitionOptions();
+          parseSelectStatement();
+        } else {
+          // No columns, but there must be a select statement
+          parseTableOptions();
+          parsePartitionOptions();
+          parseSelectStatement();
+        }
+
+        expect(SEMI_COLON);
+
+        return new TableData(tableName, columns);
       } else {
-        // No columns, but there must be a select statement
-        parseTableOptions();
-        parsePartitionOptions();
-        parseSelectStatement();
+        eatStatement();
+        return null;
       }
-
-      expect(SEMI_COLON);
-
-      return new TableData(tableName, columns);
     } else {
+      eatStatement();
       return null;
+    }
+  }
+
+  private void eatStatement() {
+    while (!eof() && !accept(SEMI_COLON)) {
+      consumeToken();
     }
   }
 


### PR DESCRIPTION
Without this change, the DDL parser gives up as soon as it encounters something that isn't CREATE TABLE.  I don't think this change is perfect but it's a reasonable stopgap and it allows the Ronin sample app's schema to be parsed.
