### PR TITLE
now inheriting the gosu-project-parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,33 +9,19 @@
 
   <name>Tosa</name>
 
+  <parent>
+    <groupId>org.gosu-lang</groupId>
+    <artifactId>gosu-project-parent</artifactId>
+    <version>2</version>
+  </parent>
+
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <id>gosu-lang.org</id>
-      <name>Official Gosu website</name>
-      <url>http://gosu-lang.org/m2</url>
+      <id>gosu-lang.org-releases</id>
+      <name>Official Gosu website (releases)</name>
+      <url>http://gosu-lang.org/repositories/m2/releases</url>
     </repository>
   </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <id>gosu-lang.org</id>
-      <name>Official Gosu website</name>
-      <url>http://gosu-lang.org/m2</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <dependencies>
     <dependency>
@@ -96,15 +82,6 @@
       <plugin>
         <groupId>org.gosu-lang</groupId>
         <artifactId>maven-gosu-plugin</artifactId>
-        <version>1.0</version>
-        <executions>
-          <execution>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>insert-gosu-artifact</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <gosuVersion>0.9-SNAPSHOT</gosuVersion>
           <includeImpl>true</includeImpl> <!-- TODO: naughty, naughty -->
@@ -113,16 +90,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3.2</version>
         <configuration>
           <archive>
             <manifest>
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
             <manifestEntries>
-	            <Gosu-Typeloaders>tosa.loader.DBTypeLoader</Gosu-Typeloaders>
+              <Gosu-Typeloaders>tosa.loader.DBTypeLoader</Gosu-Typeloaders>
               <Contains-Sources>gs, gsx</Contains-Sources>
-	          </manifestEntries>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
This allowed me to reduce your pom.xml by taking out a lot of the config that's common to the other gosu projects.  It also ensures that you're pointing to the new repository structure that I put in place today.
