### PR TITLE
Generate OSGi headers for the bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,18 @@
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <excludeDependencies>*;groupId=org.gosu-lang.tosa</excludeDependencies>
+          <instructions>
+            <_include>bnd.bnd</_include>
+          </instructions>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/tosa-loader/bnd.bnd
+++ b/tosa-loader/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-SymbolicName=org.gosu-lang.tosa
+Export-Package=tosa.*
+Gosu-Typeloaders=tosa.loader.DBTypeLoader
+Contains-Sources=gs, gsx

--- a/tosa-loader/pom.xml
+++ b/tosa-loader/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>tosa-loader</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <name>Tosa Typeloader</name>
 
@@ -56,21 +56,6 @@
         <artifactId>maven-gosu-plugin</artifactId>
         <configuration>
           <includeImpl>true</includeImpl> <!-- TODO: naughty, naughty -->
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-            </manifest>
-            <manifestEntries>
-              <Gosu-Typeloaders>tosa.loader.DBTypeLoader</Gosu-Typeloaders>
-              <Contains-Sources>gs, gsx</Contains-Sources>
-            </manifestEntries>
-          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/tosa-runtime/bnd.bnd
+++ b/tosa-runtime/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-SymbolicName=org.gosu-lang.tosa.runtime
+Export-Package=tosa.*
+Fragment-Host=org.gosu-lang.tosa
+Import-Package=!tosa.*,*

--- a/tosa-runtime/pom.xml
+++ b/tosa-runtime/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>tosa-runtime</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <name>Tosa</name>
 


### PR DESCRIPTION
Here is the patch to generate OSGi headers for the Tosa. It will allow using the library in the OSGi environment (provided Gosu is wrapped into OSGi bundles as well).
